### PR TITLE
Fix benchmarking

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -17,29 +17,25 @@ import qualified HaskellWorks.Data.Simd.Logical.Avx2     as AVX2
 import qualified HaskellWorks.Data.Simd.Logical.Stock    as STOCK
 import qualified System.Directory                        as IO
 
-runCmpEqWord8sAvx2 :: FilePath -> IO [DVS.Vector Word64]
-runCmpEqWord8sAvx2 filePath = do
-  bs <- LBS.readFile filePath
+runCmpEqWord8sAvx2 :: LBS.ByteString -> IO [DVS.Vector Word64]
+runCmpEqWord8sAvx2 bs = do
   let vs = asVector64s 64 bs
   return $ if CAP.avx2Enabled
     then AVX2.cmpEqWord8s (fromIntegral (ord '8')) <$> vs
     else []
 
-runCmpEqWord8sStock :: FilePath -> IO [DVS.Vector Word64]
-runCmpEqWord8sStock filePath = do
-  bs <- LBS.readFile filePath
+runCmpEqWord8sStock :: LBS.ByteString -> IO [DVS.Vector Word64]
+runCmpEqWord8sStock bs = do
   let vs = asVector64s 64 bs
   return $ STOCK.cmpEqWord8s (fromIntegral (ord '8')) <$> vs
 
-runAndBitsAvx2 :: FilePath -> IO [DVS.Vector Word64]
-runAndBitsAvx2 filePath = do
-  bs <- LBS.readFile filePath
+runAndBitsAvx2 :: LBS.ByteString -> IO [DVS.Vector Word64]
+runAndBitsAvx2 bs = do
   let vs = asVector64s 64 bs
   return $ (\v -> AVX2.andBits v v) <$> vs
 
-runAndBitsStock :: FilePath -> IO [DVS.Vector Word64]
-runAndBitsStock filePath = do
-  bs <- LBS.readFile filePath
+runAndBitsStock :: LBS.ByteString -> IO [DVS.Vector Word64]
+runAndBitsStock bs = do
   let vs = asVector64s 64 bs
   return $ (\v -> STOCK.andBits v v) <$> vs
 
@@ -47,18 +43,24 @@ benchcmpEqWord8s :: IO [Benchmark]
 benchcmpEqWord8s = do
   entries <- IO.listDirectory "data/bench"
   let files = ("data/bench/" ++) <$> (".csv" `isSuffixOf`) `filter` entries
-  benchmarks <- forM files $ \file -> return $ mempty
-    <> [bench ("hw-simd/cmpEqWord8s/avx2/"  <> file) (nfIO (runCmpEqWord8sAvx2  file))]
-    <> [bench ("hw-simd/cmpEqWord8s/stock/" <> file) (nfIO (runCmpEqWord8sStock file))]
+  benchmarks <- forM files $ \file -> return $
+    [ env (LBS.readFile file) $ \bs -> bgroup file
+      [ bench ("hw-simd/cmpEqWord8s/avx2/"  <> file) (nfIO (runCmpEqWord8sAvx2  bs))
+      , bench ("hw-simd/cmpEqWord8s/stock/" <> file) (nfIO (runCmpEqWord8sStock bs))
+      ]
+    ]
   return (join benchmarks)
 
 benchAndBits :: IO [Benchmark]
 benchAndBits = do
   entries <- IO.listDirectory "data/bench"
   let files = ("data/bench/" ++) <$> (".csv" `isSuffixOf`) `filter` entries
-  benchmarks <- forM files $ \file -> return $ mempty
-    <> [bench ("hw-simd/andBits/avx2/"  <> file) (nfIO (runAndBitsAvx2  file))]
-    <> [bench ("hw-simd/andBits/stock/" <> file) (nfIO (runAndBitsStock file))]
+  benchmarks <- forM files $ \file -> return $
+    [ env (LBS.readFile file) $ \bs -> bgroup file
+      [ bench ("hw-simd/andBits/avx2/"  <> file) (nfIO (runAndBitsAvx2  bs))
+      , bench ("hw-simd/andBits/stock/" <> file) (nfIO (runAndBitsStock bs))
+      ]
+    ]
   return (join benchmarks)
 
 main :: IO ()


### PR DESCRIPTION
```
$ ./project.sh bench
Resolving dependencies...
Build profile: -w ghc-8.6.5 -O2
In order, the following will be built (use -v for more details):
 - hw-simd-0.1.1.5 (bench:bench) (first run)
Preprocessing benchmark 'bench' for hw-simd-0.1.1.5..
Building benchmark 'bench' for hw-simd-0.1.1.5..
Running 1 benchmarks...
Benchmark bench: RUNNING...
benchmarking data/bench/majestic_million.csv/hw-simd/cmpEqWord8s/avx2/data/bench/majestic_million.csv
time                 17.21 ms   (17.12 ms .. 17.31 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 17.30 ms   (17.26 ms .. 17.38 ms)
std dev              138.6 μs   (77.57 μs .. 204.2 μs)

benchmarking data/bench/majestic_million.csv/hw-simd/cmpEqWord8s/stock/data/bench/majestic_million.csv
time                 34.10 ms   (33.88 ms .. 34.41 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 34.13 ms   (34.02 ms .. 34.25 ms)
std dev              242.3 μs   (170.7 μs .. 370.6 μs)

benchmarking data/bench/data-0001000.csv/hw-simd/cmpEqWord8s/avx2/data/bench/data-0001000.csv
time                 29.86 μs   (29.79 μs .. 29.95 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 29.97 μs   (29.86 μs .. 30.19 μs)
std dev              523.2 ns   (293.6 ns .. 893.9 ns)
variance introduced by outliers: 14% (moderately inflated)

benchmarking data/bench/data-0001000.csv/hw-simd/cmpEqWord8s/stock/data/bench/data-0001000.csv
time                 64.70 μs   (64.58 μs .. 64.82 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 64.65 μs   (64.55 μs .. 64.77 μs)
std dev              372.4 ns   (317.8 ns .. 437.2 ns)

benchmarking data/bench/data-0010000.csv/hw-simd/cmpEqWord8s/avx2/data/bench/data-0010000.csv
time                 98.25 μs   (98.00 μs .. 98.53 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 98.12 μs   (97.93 μs .. 98.31 μs)
std dev              647.7 ns   (541.2 ns .. 784.0 ns)

benchmarking data/bench/data-0010000.csv/hw-simd/cmpEqWord8s/stock/data/bench/data-0010000.csv
time                 215.4 μs   (215.0 μs .. 215.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 215.6 μs   (215.2 μs .. 216.0 μs)
std dev              1.401 μs   (1.162 μs .. 1.717 μs)

benchmarking data/bench/data-0100000.csv/hw-simd/cmpEqWord8s/avx2/data/bench/data-0100000.csv
time                 1.050 ms   (1.046 ms .. 1.054 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.053 ms   (1.049 ms .. 1.059 ms)
std dev              16.28 μs   (9.341 μs .. 23.92 μs)

benchmarking data/bench/data-0100000.csv/hw-simd/cmpEqWord8s/stock/data/bench/data-0100000.csv
time                 2.195 ms   (2.189 ms .. 2.199 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.198 ms   (2.195 ms .. 2.202 ms)
std dev              11.89 μs   (9.390 μs .. 16.62 μs)

benchmarking data/bench/data-1000000.csv/hw-simd/cmpEqWord8s/avx2/data/bench/data-1000000.csv
time                 11.31 ms   (11.16 ms .. 11.41 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 11.50 ms   (11.41 ms .. 11.75 ms)
std dev              379.8 μs   (75.65 μs .. 693.2 μs)
variance introduced by outliers: 10% (moderately inflated)

benchmarking data/bench/data-1000000.csv/hw-simd/cmpEqWord8s/stock/data/bench/data-1000000.csv
time                 23.24 ms   (22.57 ms .. 24.06 ms)
                     0.996 R²   (0.991 R² .. 1.000 R²)
mean                 22.75 ms   (22.59 ms .. 23.23 ms)
std dev              568.5 μs   (205.1 μs .. 1.053 ms)

benchmarking data/bench/majestic_million.csv/hw-simd/andBits/avx2/data/bench/majestic_million.csv
time                 16.84 ms   (16.76 ms .. 16.96 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 16.91 ms   (16.86 ms .. 16.96 ms)
std dev              124.1 μs   (101.4 μs .. 166.8 μs)

benchmarking data/bench/majestic_million.csv/hw-simd/andBits/stock/data/bench/majestic_million.csv
time                 30.68 ms   (30.48 ms .. 30.93 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 30.85 ms   (30.75 ms .. 30.95 ms)
std dev              214.1 μs   (171.5 μs .. 264.9 μs)

benchmarking data/bench/data-0001000.csv/hw-simd/andBits/avx2/data/bench/data-0001000.csv
time                 29.65 μs   (29.56 μs .. 29.71 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 29.58 μs   (29.51 μs .. 29.64 μs)
std dev              224.4 ns   (191.2 ns .. 265.1 ns)

benchmarking data/bench/data-0001000.csv/hw-simd/andBits/stock/data/bench/data-0001000.csv
time                 59.11 μs   (58.67 μs .. 59.65 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 59.06 μs   (58.84 μs .. 59.34 μs)
std dev              795.9 ns   (619.5 ns .. 1.084 μs)

benchmarking data/bench/data-0010000.csv/hw-simd/andBits/avx2/data/bench/data-0010000.csv
time                 97.36 μs   (97.15 μs .. 97.56 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 97.47 μs   (97.30 μs .. 97.64 μs)
std dev              573.5 ns   (454.9 ns .. 765.8 ns)

benchmarking data/bench/data-0010000.csv/hw-simd/andBits/stock/data/bench/data-0010000.csv
time                 191.7 μs   (190.9 μs .. 192.4 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 191.1 μs   (190.5 μs .. 191.6 μs)
std dev              1.937 μs   (1.679 μs .. 2.189 μs)

benchmarking data/bench/data-0100000.csv/hw-simd/andBits/avx2/data/bench/data-0100000.csv
time                 1.040 ms   (1.037 ms .. 1.044 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.045 ms   (1.042 ms .. 1.048 ms)
std dev              10.02 μs   (8.256 μs .. 12.73 μs)

benchmarking data/bench/data-0100000.csv/hw-simd/andBits/stock/data/bench/data-0100000.csv
time                 2.016 ms   (2.007 ms .. 2.027 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.011 ms   (2.005 ms .. 2.018 ms)
std dev              21.40 μs   (16.77 μs .. 28.04 μs)

benchmarking data/bench/data-1000000.csv/hw-simd/andBits/avx2/data/bench/data-1000000.csv
time                 11.34 ms   (11.28 ms .. 11.40 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 11.40 ms   (11.37 ms .. 11.43 ms)
std dev              73.88 μs   (59.14 μs .. 97.11 μs)

benchmarking data/bench/data-1000000.csv/hw-simd/andBits/stock/data/bench/data-1000000.csv
time                 20.60 ms   (20.44 ms .. 20.81 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 20.80 ms   (20.72 ms .. 20.87 ms)
std dev              190.4 μs   (156.2 μs .. 251.9 μs)

Benchmark bench: FINISH
```